### PR TITLE
Some enhancements to allow configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "data2xml",
     "description": "A data to XML converter with a nice interface (for NodeJS).",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "author": {
         "name":"Andrew Chilton",
         "email":"chilts@appsattic.com",


### PR DESCRIPTION
Hello !

This is a proposition to allow some user to customize the data2xml behaviour.

I've added a data2xml.conf object. It's intended to allow library user to specify in which json property the XML attributes are stored. For example, libxml-to-js stores attributes in '@', and xml values in '#'.

The second change I've made allows overriding the different functions. For example :

var data2xml = require('data2xml');

// Wrap xml start tag function to clean element names.
var _makeStartTag = data2xml.makeStartTag;
data2xml.makeStartTag = function(name, attr) {
  // Avoid spaces in element name, and removes namespaces.
  return _makeStartTag(name.replace(/ /g, '_').replace(/^.*:/, ''), attr); 
}

The unit tests are good, but I did not add new ones to check the configuration features.
I hope these enhancements will interest you.

Bye.

Damien.
