### PR TITLE
Small tweak to package.json fixes Windows error for 'npm test'

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
         "data", "xml", "data2xml", "datatoxml", "js2xml", "jstoxml", "json2xml", "jsontoxml"
     ],
     "scripts" : {
-        "test" : "./node_modules/tap/bin/tap.js test/*.js"
+        "test" : "node node_modules/tap/bin/tap.js test/*.js"
     }
 }


### PR DESCRIPTION
Windows doesn't like dot slash notation, so I swapped `./` for `node` in `package.json` to fix this. I'm happy to report that all of the unit tests pass in Windows!

```
$ npm test

> data2xml@0.8.0 test c:\Documents and Settings\apenneba\Desktop\node-data2xml
> node node_modules/tap/bin/tap.js test/*.js

ok test/basics.js ....................................... 8/8
ok test/config-2.js ..................................... 5/5
ok test/config.js ....................................... 3/3
ok test/doc-xml.js ...................................... 2/2
ok test/load.js ......................................... 2/2
ok test/xml-generation.js ............................. 14/14
total ................................................. 34/34

ok
```
