### PR TITLE
Tightened screws in .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,8 @@
 {
   "es5": true,
   "indent": 4,
+  "eqeqeq": true,
+  "curly": true,
+  "camelcase": true,
   "quotmark": "single"
 }


### PR DESCRIPTION
I added a few more constraints in `.jshintrc`, such as preferring triple equals (disables auto-casting). Your code is sufficiently well written that none of these extra rules trigger JSHint warnings!
