### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,7 @@
     "email": "andychilton@gmail.com",
     "url": "http://chilts.org/"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/chilts/data2xml/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "data",
     "xml",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/